### PR TITLE
Start of basic workspace management

### DIFF
--- a/pm.py
+++ b/pm.py
@@ -370,7 +370,12 @@ class ProjectManager(sublime_plugin.WindowCommand):
 
         elif action >= len(self.options):
             action = action-len(self.options)
-            self.manager.switch_project(self.projects[action])
+            pdata = self.manager.get_project_data(self.projects[action])
+            if pdata.get('workspaces'):
+                workspace_items = [[w['name'],w['path']] for w in pdata['workspaces']]
+                self.show_quick_panel(workspace_items, lambda a: subl([workspace_items[a][1]]))
+            else:
+                self.manager.switch_project(self.projects[action])
 
 
 class ProjectManagerAddProject(sublime_plugin.WindowCommand):


### PR DESCRIPTION
When a project is selected in the project manager, if it has any associated workspace files, the user will be prompted to select a workspace to open.

To associate a workspace with a project, add a workspaces key to the project file, with each workspace having a "name" and a "path" value, where name represents a friendly name for the workspace, and path represents the path to the sublime-workspace file (similar to how folders are represented in the project file).
