### PR TITLE
Collapse user home directory path to tilde

### DIFF
--- a/project_manager.py
+++ b/project_manager.py
@@ -173,6 +173,8 @@ class Manager:
         j = JsonFile(os.path.join(self.primary_dir, 'recent.json'))
         recent = j.load([])
         pname = self.project_file_name(project)
+        if sublime.platform() != 'windows':
+            pname = pname.replace(os.path.expanduser('~'), '~')
         if pname not in recent:
             recent.append(pname)
         else:
@@ -226,6 +228,8 @@ class Manager:
     def add_project(self):
         def add_callback(project):
             pd = self.window.project_data()
+            if sublime.platform() != 'windows':
+                pd['folders'][0]['path'] = pd['folders'][0]['path'].replace(os.path.expanduser('~'), '~')
             f = os.path.join(self.primary_dir, '%s.sublime-project' % project)
             if pd:
                 JsonFile(f).save(pd)


### PR DESCRIPTION
So, one thing upfront, I'm not very familiar with python so I apologize if there's a more elegant way to do this.

But, I have 3 devices I primarily use (all OS X) and sync my sublime settings between them, however one of them has a different username (and thus home directory) than the other two. Because of this, all my project paths are wrong when switching to this device.

By replacing the segment of the path that points to the user's home directory with "~", all that is required is that the given user's directory structure is the same between accounts/devices.

Now, I also added a check for windows because I am completely unsure with how this would work on it, but I know it's perfectly valid on OS X and, from what I understand, linux as well.