### PR TITLE
Expand home directory in user configured dirs

### DIFF
--- a/project_manager.py
+++ b/project_manager.py
@@ -112,7 +112,7 @@ class Manager:
 
         self.projects_path = []
         for folder in user_projects_dirs:
-            if os.path.isdir(folder):
+            if os.path.isdir(os.path.expanduser(folder)):
                 self.projects_path.append(folder)
 
         if not self.projects_path:


### PR DESCRIPTION
User configured folders were ignored if it contained ~ for $HOME, although the home directory is expanded later on.