### PR TITLE
Fix crashing when switching between projects

### DIFF
--- a/project_manager.py
+++ b/project_manager.py
@@ -376,14 +376,14 @@ class Manager:
         self.check_project(project)
         self.close_project_by_window(self.window)
         self.close_project_by_name(project)
-        subl(self.project_file_name(project))
+        subl(self.project_workspace(project))
 
     @dont_close_windows_when_empty
     def open_in_new_window(self, project):
         self.update_recent(project)
         self.check_project(project)
         self.close_project_by_name(project)
-        subl('-n', self.project_file_name(project))
+        subl('-n', self.project_workspace(project))
 
     def _remove_project(self, project):
         answer = sublime.ok_cancel_dialog('Remove "%s" from Project Manager?' % project)

--- a/project_manager.py
+++ b/project_manager.py
@@ -376,14 +376,14 @@ class Manager:
         self.check_project(project)
         self.close_project_by_window(self.window)
         self.close_project_by_name(project)
-        subl(self.project_workspace(project))
+        subl('--project', self.project_workspace(project))
 
     @dont_close_windows_when_empty
     def open_in_new_window(self, project):
         self.update_recent(project)
         self.check_project(project)
         self.close_project_by_name(project)
-        subl('-n', self.project_workspace(project))
+        subl('-n', '--project', self.project_workspace(project))
 
     def _remove_project(self, project):
         answer = sublime.ok_cancel_dialog('Remove "%s" from Project Manager?' % project)

--- a/project_manager.py
+++ b/project_manager.py
@@ -304,6 +304,10 @@ class Manager:
                 if "folders" in pd:
                     for folder in pd["folders"]:
                         if "path" in folder:
+                            folder["name"] = project
+                            folder["file_exclude_patterns"] = list()
+                            folder["folder_exclude_patterns"] = list()
+                            folder["binary_file_patterns"] = list()
                             path = folder["path"]
                             if sublime.platform() == "windows":
                                 folder["path"] = expand_path(path, relative_to=pf)


### PR DESCRIPTION
**Fixes:** #88 

After much trial and error, opening the `.sublime-workspace` file instead of the `.sublime-project` file resolves the crash bug OSX users have been experiencing.

The only strange artifact I've been experiencing is this randomly generated file whenever switching between projects.
<img width="260" alt="Screen Shot 2019-07-23 at 7 56 41 PM" src="https://user-images.githubusercontent.com/1457327/61755177-68613480-ad84-11e9-9c67-812fcdff4207.png">
I've gotten used to <kbd>⌘</kbd>+<kbd>W</kbd> by now.

@randy3k 