### PR TITLE
Cache projects list to optimize the time it takes to open quick panel

### DIFF
--- a/project_manager.py
+++ b/project_manager.py
@@ -19,6 +19,11 @@ def plugin_loaded():
     all_info = AllProjectsInfo()
 
 
+def plugin_unloaded():
+    global all_info
+    all_info = None
+
+
 def subl(*args):
     executable_path = sublime.executable_path()
     if sublime.platform() == 'osx':


### PR DESCRIPTION
The list of projects is cached in a global cache and invalidated at appropriate times.

This is quite an invasive change and there could be issues related to invalidation (I've just made the change and will be testing it going forward).

I will understand if you don't want this integrated since a global cache is kind of a dirty thing but then I will just run my local version since I was about to get crazy due to getting accidental edits. I have about 150 projects added to the list and showing the list was taking too much time due to all the file IO.

Resolves #100