### PR TITLE
fix clickable project directory path in quick panel

### DIFF
--- a/project_manager.py
+++ b/project_manager.py
@@ -100,8 +100,9 @@ def format_directory(item, folder):
     if hasattr(sublime, "QuickPanelItem"):
         return sublime.QuickPanelItem(
             item,
-            '<a href=\'subl:open_dir {"dir": "%s"}\'>%s</a>' % (
-                folder, pretty_path(folder)))
+            '<a href="%s">%s</a>' % (
+                sublime.command_url('open_dir', {'dir': folder}),
+                pretty_path(folder)))
     else:
         return [item, pretty_path(folder)]
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6594915/202124046-2e24f81a-7698-4f04-b80a-c45600437b3c.png)

`sublime.command_url()` was introduced in ST 4075, which is before `QuickPanelItem` (ST 4083).
The quotes in `href` should be encoded if it's done manually.