### PR TITLE
Add updated action names to menu

### DIFF
--- a/support/Main.sublime-menu
+++ b/support/Main.sublime-menu
@@ -24,27 +24,27 @@
                     },
                     {
                         "caption": "Open Project",
-                        "command": "project_manager", "args": {"action": "switch"}
+                        "command": "project_manager", "args": {"action": "open_project"}
                     },
                     {
                         "caption": "Open Project in New Window",
-                        "command": "project_manager", "args": {"action": "new"}
+                        "command": "project_manager", "args": {"action": "open_project_in_new_window"}
                     },
                     {
                         "caption": "Append Project",
-                        "command": "project_manager", "args": {"action": "append"}
+                        "command": "project_manager", "args": {"action": "append_project"}
                     },
                     {
                         "caption": "Remove Project",
-                        "command": "project_manager", "args": {"action": "remove"}
+                        "command": "project_manager", "args": {"action": "remove_project"}
                     },
                     {
                         "caption": "Edit Project",
-                        "command": "project_manager", "args": {"action": "edit"}
+                        "command": "project_manager", "args": {"action": "edit_project"}
                     },
                     {
                         "caption": "Rename Project",
-                        "command": "project_manager", "args": {"action": "rename"}
+                        "command": "project_manager", "args": {"action": "rename_project"}
                     },
                     {
                         "caption": "Refresh Projects",


### PR DESCRIPTION
The renamed actions in 34f3073707ca45f090ff8a049f5df23df82b17e7 were not extended to the menu. This fixes that.