### PR TITLE
fix: "Remove Dead Projects" doesn't work

### DIFF
--- a/project_manager.py
+++ b/project_manager.py
@@ -712,7 +712,7 @@ class ProjectManagerCommand(sublime_plugin.WindowCommand):
             "import_sublime_project",
             "refresh_projects",
             "clear_recent_projects",
-            "remove_dead_project"
+            "remove_dead_projects"
         ]
 
         def callback(i):


### PR DESCRIPTION
When select "Remove Dead Projects" from the command palette, 

```
Traceback (most recent call last):
  File "C:\Users\jfcherng\AppData\Roaming\Sublime Text\Installed Packages\ProjectManager.sublime-package\project_manager.py", line 721, in callback
  File "C:\Users\jfcherng\AppData\Roaming\Sublime Text\Installed Packages\ProjectManager.sublime-package\project_manager.py", line 687, in run
AttributeError: 'ProjectManagerCommand' object has no attribute 'remove_dead_project'
```